### PR TITLE
hooks: Add start lifecycle hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import 'reflect-metadata';
 import { Container } from 'typedi';
 import initModules from './initialise-modules';
+import startModules from './start-modules';
 import { N9NodeRouting } from './models/routing.models';
 import { registerShutdown } from './register-system-signals';
 import { requestIdFilter } from './requestid';
@@ -81,7 +82,7 @@ export default async function(options?: N9NodeRouting.Options): Promise<N9NodeRo
 	}
 	Container.set('N9HttpClient', new N9HttpClient());
 
-	// Init every modules
+	// Execute all *.init.ts files in modules before app started listening on the HTTP Port
 	await initModules(options.path, options.log);
 	const returnObject = await expressAppStarter(options);
 	await bindSpecificRoutes(returnObject.app, options);
@@ -90,6 +91,9 @@ export default async function(options?: N9NodeRouting.Options): Promise<N9NodeRo
 	if (options.shutdown.enableGracefulShutdown) {
 		registerShutdown(options.log, options.shutdown, returnObject.server);
 	}
+
+	// Execute all *.started.ts files in modules after app started listening on the HTTP Port
+	await startModules(options.path, options.log);
 
 	return returnObject;
 }

--- a/src/start-modules.ts
+++ b/src/start-modules.ts
@@ -1,0 +1,16 @@
+import { N9Log } from '@neo9/n9-node-log';
+import * as glob from 'glob-promise';
+import { join } from 'path';
+
+export default async function(path: string, log: N9Log): Promise<any> {
+	const initFiles = await glob('**/*.started.+(ts|js)', { cwd: path });
+
+	await Promise.all(initFiles.map((file) => {
+		const moduleName = file.split('/').slice(-2)[0];
+		log.info(`Start module ${moduleName}`);
+
+		let module = require(join(path, file));
+		module = module.default ? module.default : module;
+		return module(log);
+	}));
+}

--- a/test/fixtures/micro-lifecycle-hooks/feature/feature.init.ts
+++ b/test/fixtures/micro-lifecycle-hooks/feature/feature.init.ts
@@ -1,0 +1,5 @@
+import { N9Log } from '@neo9/n9-node-log';
+
+export default async function(log: N9Log): Promise<void> {
+	log.info('feature init');
+}

--- a/test/fixtures/micro-lifecycle-hooks/feature/feature.started.ts
+++ b/test/fixtures/micro-lifecycle-hooks/feature/feature.started.ts
@@ -1,0 +1,5 @@
+import { N9Log } from '@neo9/n9-node-log';
+
+export default async function(log: N9Log): Promise<void> {
+	log.info('feature started');
+}

--- a/test/micro-lifecycle-hooks.ts
+++ b/test/micro-lifecycle-hooks.ts
@@ -1,0 +1,40 @@
+import { N9Log } from '@neo9/n9-node-log';
+import test, { Assertions } from 'ava';
+import { Express } from 'express';
+import { Server } from 'http';
+import { join } from 'path';
+import * as stdMock from 'std-mocks';
+
+import n9NodeRouting, { N9HttpClient } from '../src';
+import commons from './fixtures/commons';
+
+const closeServer = async (server: Server) => {
+	return new Promise((resolve) => {
+		server.close(resolve);
+	});
+};
+
+async function init(): Promise<{ app: Express, server: Server }> {
+	stdMock.use({ print: commons.print });
+	const MICRO_LIFECYCLE_HOOKS = join(__dirname, 'fixtures/micro-lifecycle-hooks/');
+	return await n9NodeRouting({
+		path: MICRO_LIFECYCLE_HOOKS,
+	});
+}
+
+test('[Lifecycle Hooks] init and started hooks called', async (t: Assertions) => {
+	const { server } = await init();
+
+	stdMock.restore();
+	const output = stdMock.flush().stdout.filter(commons.excludeSomeLogs);
+
+	// Logs on stdout
+	t.true(output[0].includes('Init module feature'), 'Init module feature');
+	t.true(output[1].includes('feature init'), 'feature init');
+	t.true(output[2].includes('Listening on port 5000'), 'Listening on port 5000');
+	t.true(output[3].includes('Start module feature'), 'Start module feature');
+	t.true(output[4].includes('feature started'), 'feature started');
+
+	// Close server
+	await closeServer(server);
+});


### PR DESCRIPTION
This PR adds a new lifecycle hooks called 'started' that is triggered after the server has initialised and is listening for HTTP requests. The hook work the same as the 'init' hook: all files named `*.started.ts` will be executed.